### PR TITLE
Fix the get_xy typo

### DIFF
--- a/get_xy.py
+++ b/get_xy.py
@@ -216,5 +216,5 @@ for target_cell_name in target_cell_names:
             model_file_prefix = save_xy_path + target_cell_name + '_' + direction + '_' + str(percentile_down) + 'p'
             save_file = model_file_prefix + "_Y_class"
             print("saved", save_file)
-            npY = npY_class_up if direction == "up" else npY_class_down
+            npY = npY_class_up if direction == "Up" else npY_class_down
             np.savez(save_file, npY)


### PR DESCRIPTION
Found a typo in get_xy.py thats gonna save down_regulation_Y_class.npy  for up_regulation_Y_class.npy. 